### PR TITLE
Fix recordDate not working when date is null

### DIFF
--- a/src/main/kotlin/xyz/crossward/entities/Entry.kt
+++ b/src/main/kotlin/xyz/crossward/entities/Entry.kt
@@ -26,12 +26,9 @@ data class EntryId(
 
 private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
-fun Entry.localDate(): LocalDate? {
-    if (this.date != null) {
-        return LocalDate.parse(this.date, formatter)
-    }
-    return null;
-}
+fun Entry.localDate(): LocalDate?  =
+        this.date?.let { LocalDate.parse(this.date, formatter) }
+
 
 fun LocalDate.entryDateString(): String {
     return this.format(formatter)

--- a/src/main/kotlin/xyz/crossward/entities/Entry.kt
+++ b/src/main/kotlin/xyz/crossward/entities/Entry.kt
@@ -27,7 +27,10 @@ data class EntryId(
 private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
 fun Entry.localDate(): LocalDate? {
-    return LocalDate.parse(this.date, formatter)
+    if (this.date != null) {
+        return LocalDate.parse(this.date, formatter)
+    }
+    return null;
 }
 
 fun LocalDate.entryDateString(): String {


### PR DESCRIPTION
With our addition of entry.localDate, if you try to record an entry without providing a date you get a NullPointerException. This fix makes entry.localDate just return null if date is null, avoiding the issue. However I'm open to other, more kotlinic ways of fixing this.